### PR TITLE
In the case that Split doesn't find anything, it returns a list of length 1

### DIFF
--- a/sdmon/main.go
+++ b/sdmon/main.go
@@ -136,7 +136,7 @@ func runApp(c *cli.Context) error {
 	e.healthyInterval = c.Duration("holdoff")
 	for _, u := range c.StringSlice("unit") {
 		parts := strings.Split(u, ":")
-		if len(parts) == 0 {
+		if len(parts) == 1 {
 			e.displayName[parts[0]+".service"] = parts[0]
 		} else {
 			e.displayName[parts[0]+".service"] = parts[1]


### PR DESCRIPTION
Current version crashes if you don't have a ":" in the unit name. This fixes that